### PR TITLE
Fix zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,6 @@ you prefer inside of Nix shells.
 
 ## Usage
 
-Add this to your shell configuration, replacing `fish` with your shell:
-
-```fish
-nix-your-shell fish | source
-```
-
 `nix-your-shell` will print out shell environment code you can source to
 activate `nix-your-shell`.
 
@@ -23,15 +17,30 @@ The shell code will transform `nix` and `nix-shell` invocations that call
 (unless you've already added one) so that it drops you into _your_ shell,
 rather than `bash`.
 
-You may want to only use `nix-your-shell` if it's installed, like this (for `fish`):
+
+### Fish
+
+Add to your `~/.config/fish/config.fish`:
 
 ```fish
 if command -q nix-your-shell
-    nix-your-shell fish | source
+  nix-your-shell fish | source
 end
 ```
 
+### Zsh
+
+Add to your `~/.zshrc`:
+
+```
+if command -v nix-your-shell > /dev/null; then
+  nix-your-shell zsh | source /dev/stdin
+fi
+```
+
 ## Installation
+
+### nix-env
 
 To install the latest version with `nix-env`, use:
 
@@ -41,11 +50,15 @@ nix-env --install --file https://github.com/MercuryTechnologies/nix-your-shell/a
 
 You can later remove the installed program with `nix-env --uninstall nix-your-shell`.
 
+### nix run
+
 Run dynamically with `nix run`:
 
 ```sh
 nix run github:MercuryTechnologies/nix-your-shell
 ```
+
+### Flakes
 
 Add to a NixOS flake configuration:
 

--- a/data/env.zsh
+++ b/data/env.zsh
@@ -1,5 +1,5 @@
 # If you see this output, you probably forgot to pipe it into `source`:
-# nix-your-shell | source
+# nix-your-shell | source /dev/stdin
 
 function nix-shell () {
     nix-your-shell nix-shell "$@"

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ fn main() -> eyre::Result<()> {
         Command::Env => {
             let mut shell_code = match shell.kind {
                 ShellKind::Zsh => {
-                    include_str!("../data/env.fish")
+                    include_str!("../data/env.zsh")
                 }
 
                 ShellKind::Fish => {


### PR DESCRIPTION
1. zsh `source` requires a filename, so we use `nix-your-shell zsh | source /dev/stdin` instead.
2. `nix-your-shell zsh` was printing the fish code instead of the zsh code due to a copy-pasting error (lol). Fix that.

Also clean up the README a bit.

Closes #4