### PR TITLE
Add `--` to `nix-your-shell` invocations

### DIFF
--- a/data/env.fish
+++ b/data/env.fish
@@ -2,9 +2,9 @@
 # nix-your-shell | source
 
 function nix-shell --description "Start an interactive shell based on a Nix expression"
-    nix-your-shell nix-shell $argv
+    nix-your-shell nix-shell -- $argv
 end
 
 function nix --description "Reproducible and declarative configuration management"
-    nix-your-shell nix $argv
+    nix-your-shell nix -- $argv
 end

--- a/data/env.zsh
+++ b/data/env.zsh
@@ -2,9 +2,9 @@
 # nix-your-shell | source /dev/stdin
 
 function nix-shell () {
-    nix-your-shell nix-shell "$@"
+    nix-your-shell nix-shell -- "$@"
 }
 
 function nix () {
-    nix-your-shell nix "$@"
+    nix-your-shell nix -- "$@"
 }


### PR DESCRIPTION
This fixes extra arguments. Before, you'd see this if you tried to use any arguments with `nix-shell` or `nix develop`:

```
$ nix develop --command whatever
error: unexpected argument '--command' found

  note: to pass '--command' as a value, use '-- --command'

Usage: nix-your-shell <SHELL> nix <ARGS>

For more information, try '--help'.
```