### PR TITLE
Add `data/` to files that trigger patch-level changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,5 +2,6 @@
 # See: https://github.com/marketplace/actions/labeler
 patch:
   - 'src/**/*.rs'
+  - 'data/**/*'
   - 'Cargo.toml'
   - 'Cargo.lock'


### PR DESCRIPTION
This means PRs that change files in the `data/` directory will be labeled `patch` by default.