### PR TITLE
Release version 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "nix-your-shell"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "camino",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nix-your-shell"
-version = "1.0.2"
+version = "1.1.0"
 edition = "2021"
 authors = ["Rebecca Turner <rebeccat@mercury.com>"]
 description = "A `nix` and `nix-shell` wrapper for shells other than `bash`"

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,7 @@
         final: prev: {
           nix-your-shell = final.rustPlatform.buildRustPackage {
             pname = "nix-your-shell";
-            version = "1.0.2"; # LOAD-BEARING COMMENT. See: `.github/workflows/version.yaml`
+            version = "1.1.0"; # LOAD-BEARING COMMENT. See: `.github/workflows/version.yaml`
 
             cargoLock = {
               lockFile = ./Cargo.lock;


### PR DESCRIPTION
Update version to 1.1.0 with [cargo-release](https://github.com/crate-ci/cargo-release).
Merge this PR to build and publish a new release.