### PR TITLE
Housekeeping

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -108,7 +108,7 @@ jobs:
       - name: Increment `flake.nix` version
         run: |
           sed -i \
-              -e "s/version = \"[^\"]*\"; # LOAD-BEARING COMMENT/version = \"${{ steps.new_cargo_metadata.outputs.version }}\"; # LOAD-BEARING COMMENT/" \
+              -e "s/version = \"[^\"]*\"; # @VERSION@/version = \"${{ steps.new_cargo_metadata.outputs.version }}\"; # @VERSION@/" \
               flake.nix
 
           # Commit the new changes

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -105,16 +105,6 @@ jobs:
         run: |
           echo "version=$(./.github/workflows/get-crate-version.sh)" >> "$GITHUB_OUTPUT"
 
-      - name: Increment `flake.nix` version
-        run: |
-          sed -i \
-              -e "s/version = \"[^\"]*\"; # @VERSION@/version = \"${{ steps.new_cargo_metadata.outputs.version }}\"; # @VERSION@/" \
-              flake.nix
-
-          # Commit the new changes
-          git add flake.nix
-          git commit --amend --no-edit
-
       - name: Create release PR
         id: release_pr
         uses: peter-evans/create-pull-request@v5

--- a/default.nix
+++ b/default.nix
@@ -1,14 +1,8 @@
-(
-  import
-  (
-    let
-      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
-    in
-      fetchTarball {
-        url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
-        sha256 = lock.nodes.flake-compat.locked.narHash;
-      }
-  )
-  {src = ./.;}
-)
+(import (let
+  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+in
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash;
+  }) {src = ./.;})
 .defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -16,21 +16,6 @@
         "type": "github"
       }
     },
-    "flake-utils": {
-      "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1675982352,
@@ -49,7 +34,6 @@
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -34,7 +34,23 @@
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,47 @@
 {
   "nodes": {
+    "alejandra": {
+      "inputs": {
+        "fenix": "fenix",
+        "flakeCompat": "flakeCompat",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1694541876,
+        "narHash": "sha256-lStDIPizbJipd1JpNKX1olBKzyIosyC2U/mVFwJPcZE=",
+        "owner": "kamadorueda",
+        "repo": "alejandra",
+        "rev": "e53c2c6c6c103dc3f848dbd9fbd93ee7c69c109f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kamadorueda",
+        "repo": "alejandra",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "alejandra",
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1668234453,
+        "narHash": "sha256-FmuZThToBvRsqCauYJ3l8HJoGLAY5cMULeYEKIaGrRw=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "8f219f6b36e8d0d56afa7f67e6e3df63ef013cdb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -16,7 +58,39 @@
         "type": "github"
       }
     },
+    "flakeCompat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1668226844,
+        "narHash": "sha256-G/S4FBWDAqHeBS/hfXwUCJbnaKnrQFoeeKwzvZEOgxM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "dd4767bf613bf9553eee6ff37c0996b9c876e7d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1675982352,
         "narHash": "sha256-jtx492OH5xAa6V8kwLJ/+uIQDltF0sELjR22exubL88=",
@@ -33,9 +107,27 @@
     },
     "root": {
       "inputs": {
+        "alejandra": "alejandra",
         "flake-compat": "flake-compat",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "systems": "systems"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1668182250,
+        "narHash": "sha256-PYGaOCiFvnJdVz+ZCaKF8geGdffXjJUNcMwaBHv0FT4=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "45ec315e01dc8dd1146dfeb65f0ef6e5c2efed78",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
     flake-utils.lib.eachDefaultSystem (
       system: let
         pkgs = import nixpkgs {
-          inherit system;
+          localSystem = system;
           overlays = [self.overlays.default];
         };
       in {

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs";
+    systems.url = "github:nix-systems/default";
     flake-compat = {
       url = "github:edolstra/flake-compat";
       flake = false;
@@ -12,12 +13,12 @@
   outputs = {
     self,
     nixpkgs,
+    systems,
     ...
   }:
     let
       inherit (nixpkgs) lib;
-      systems = ["aarch64-linux" "aarch64-darwin" "x86_64-darwin" "x86_64-linux"];
-      eachSystem = fn: lib.genAttrs systems (system:
+      eachSystem = fn: lib.genAttrs (import systems) (system:
         let
           pkgs = import nixpkgs {
             localSystem = system;
@@ -83,7 +84,7 @@
             meta = {
               homepage = "https://github.com/MercuryTechnologies/nix-your-shell";
               license = lib.licenses.mit;
-              platforms = systems;
+              platforms = import systems;
               mainProgram = "nix-your-shell";
             };
           };

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
     self,
     nixpkgs,
     flake-utils,
-    flake-compat,
+    ...
   }:
     let
       inherit (nixpkgs) lib;

--- a/flake.nix
+++ b/flake.nix
@@ -53,7 +53,7 @@
         manifest = lib.importTOML ./Cargo.toml;
       in
         final.rustPlatform.buildRustPackage {
-          pname = "nix-your-shell";
+          pname = manifest.package.name;
           inherit (manifest.package) version;
 
           cargoLock = {lockFile = ./Cargo.lock;};
@@ -77,10 +77,10 @@
             '';
 
           meta = {
-            homepage = "https://github.com/MercuryTechnologies/nix-your-shell";
+            inherit (manifest.package) description homepage;
             license = lib.licenses.mit;
             platforms = import systems;
-            mainProgram = "nix-your-shell";
+            mainProgram = manifest.package.name;
           };
         };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -26,9 +26,9 @@
           overlays = [self.overlays.default];
         };
       in {
-        packages = rec {
+        packages = {
           nix-your-shell = pkgs.nix-your-shell;
-          default = nix-your-shell;
+          default = self.packages.${system}.nix-your-shell;
         };
         checks = self.packages.${system};
 

--- a/flake.nix
+++ b/flake.nix
@@ -66,9 +66,9 @@
           # Native libs
           buildInputs = [];
 
-          postCheck = ''
-            cargo fmt --check && echo "\`cargo fmt\` is OK"
-            cargo clippy -- --deny warnings && echo "\`cargo clippy\` is OK"
+          preCheck = ''
+            cargo check --frozen
+            cargo clippy -- --deny warnings
           '';
 
           passthru.generate-config = shell:

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,9 @@
     flake-utils,
     flake-compat,
   }:
+    let
+      inherit (nixpkgs) lib;
+    in
     flake-utils.lib.eachDefaultSystem (
       system: let
         pkgs = import nixpkgs {
@@ -74,6 +77,13 @@
             passthru.generate-config = shell: final.runCommand "nix-your-shell-config" { } ''
               ${final.nix-your-shell}/bin/nix-your-shell ${shell} >> $out
             '';
+
+            meta = {
+              homepage = "https://github.com/MercuryTechnologies/nix-your-shell";
+              license = lib.licenses.mit;
+              platforms = flake-utils.lib.defaultSystems;
+              mainProgram = "nix-your-shell";
+            };
           };
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,7 @@
           meta = {
             inherit (manifest.package) description homepage;
             license = lib.licenses.mit;
+            maintainers = [lib.maintainers._9999years];
             platforms = import systems;
             mainProgram = manifest.package.name;
           };

--- a/flake.systems.nix
+++ b/flake.systems.nix
@@ -1,1 +1,1 @@
-[ "aarch64-darwin" "aarch64-linux" "x86_64-darwin" "x86_64-linux" ]
+["aarch64-darwin" "aarch64-linux" "x86_64-darwin" "x86_64-linux"]

--- a/flake.systems.nix
+++ b/flake.systems.nix
@@ -1,0 +1,1 @@
+[ "aarch64-darwin" "aarch64-linux" "x86_64-darwin" "x86_64-linux" ]

--- a/shell.nix
+++ b/shell.nix
@@ -1,14 +1,8 @@
-(
-  import
-  (
-    let
-      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
-    in
-      fetchTarball {
-        url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
-        sha256 = lock.nodes.flake-compat.locked.narHash;
-      }
-  )
-  {src = ./.;}
-)
+(import (let
+  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+in
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+    sha256 = lock.nodes.flake-compat.locked.narHash;
+  }) {src = ./.;})
 .defaultNix


### PR DESCRIPTION
**Any of these commits may be dropped or rebased should you disapprove.**

I recommend reviewing this PR by individual commit because of the diff-noise produced by the formatter (last commit).

1. Add `meta.mainProgram` (and other `meta` attributes) to the package.
  <https://github.com/MercuryTechnologies/nix-your-shell/pull/40/commits/af3c6a8820135c0897e77b7cc6666e99c78a3630>
3. Appease `nil` lint about unused function argument `flake-compat`, replace with `...`.
   <https://github.com/MercuryTechnologies/nix-your-shell/pull/40/commits/079602288895d5a1ebb7bbdd670cad1611235a98>
5. Remove usage of `rec` from `packages` output, prefer referencing through `self` for package aliases.
   <https://github.com/MercuryTechnologies/nix-your-shell/pull/40/commits/30ebc4953280dcced19fdab8f1ad94a688cfd3bf>
7. Remove `system` from `import nixpkgs` arguments, prefer `localSystem`.
   <https://github.com/MercuryTechnologies/nix-your-shell/pull/40/commits/82a5d248c3fe0cd1bf06666af2324f7d5b8ba12d>
   - This is a documented change in Nixpkgs, but a relatively quiet one.
   - The original `system` argument has been referred to as "legacy" since 2017.
   - See the source: <https://github.com/NixOS/nixpkgs/blob/5d2b2523a0442fd19294359b31b8535696c32984/pkgs/top-level/impure.nix#L14>
   - See the commit that changed this: <https://github.com/NixOS/nixpkgs/commit/8cd4c31d6b8c6432986edf0ec5d00d2fe1c12854>
   - Reference to `stdenv`: <https://github.com/NixOS/nixpkgs/blob/5d2b2523a0442fd19294359b31b8535696c32984/pkgs/stdenv/default.nix#L10>
8. Remove `flake-utils`.
   <https://github.com/MercuryTechnologies/nix-your-shell/pull/40/commits/61d2ab423753e4ebc799cd39ba7a4b80cf9bc817>
   - See: <https://ayats.org/blog/no-flake-utils/>
   - The title of the latest release for `flake-utils` from 2022 is: "It's a stable mess."
9. Introduce [nix-systems](https://github.com/nix-systems/nix-systems) to replace functionality of `flake-utils`.
   <https://github.com/MercuryTechnologies/nix-your-shell/pull/40/commits/898524afa011e8eb2b6f431406a9afbf8c8e9b2d>
   - This makes `systems` overrideable through usage of `nix-your-shell.inputs.systems`.
10. Adopt `nixfmt` as the flake's `formatter`.
    <https://github.com/MercuryTechnologies/nix-your-shell/pull/40/commits/d47c7a1ee367fb82805d44fc1a92e94459f97bed>
    - This is perhaps somewhat controversial. There was discussion in the issues of `nixfmt` with members of the NixOS organization about "blessing" this as the canon formatter. Unfortunately, contrary to the style preferred by many individual flake projects, they decided not to go through with it and instead are "waiting" for `nixpkgs-fmt` to be "ironed out".
    - I chose this one because:
      1. I like it.
      2. It matches the style you were already using, mostly.
    - I had to change the `sed` script and the `LOAD-BEARING COMMENT` to make it shorter, so that `nixfmt` doesn't wrap the line. Since `sed` can't do multiline matching replacement easily, this was the solution that resisted me the least. I recommend taking a look at its replacement, and advising me further if need-be. No matter the flake's `formatter`, making this mechanism less fragine would be a good idea.
     
I will also look into making another PR down the line (once I figure it out for myself) about simplifying the `version.yaml` workflow. This makes me uneasy, having a `sed` script target a comment. Ideally, that version should be based on the flake's revision, however I do understand it is necessary to be the way it is because of publishing to [crates.io](https://crates.io).