### PR TITLE
Nushell update

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ Either manually generate it:
 nix-your-shell nu | save $env.XDG_CONFIG_HOME/nushell/nix-your-shell.nu
 ```
 
-Or better yet, ensure it's kept updated alongside `nix-your-shell`. Populate file contents through home-manager:
+Or ensure it's kept updated alongside `nix-your-shell` by populate the file with [`home-manager`][home-manager]:
+
+[home-manager]: https://nix-community.github.io/home-manager/
 
 ```nix
 { config, pkgs, ... }: {

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Either manually generate it:
 nix-your-shell nu | save $env.XDG_CONFIG_HOME/nushell/nix-your-shell.nu
 ```
 
-Or ensure it's kept updated alongside `nix-your-shell` by populate the file with [`home-manager`][home-manager]:
+Or ensure it's kept updated alongside `nix-your-shell` by populating the file with [`home-manager`][home-manager]:
 
 [home-manager]: https://nix-community.github.io/home-manager/
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ fi
 ### Nushell
 
 > [!IMPORTANT]
-> Nushell version >=0.83.0 is required
+> Nushell version >=0.87.0 is required
 
 > [!NOTE]
 > Nushell requires sourced configuration files to exist before `nu` is started.
@@ -69,15 +69,15 @@ Add to your `~/.config/nushell/config.nu`:
 source nix-your-shell.nu
 ```
 
-To generate `nix-your-shell.nu` file:
+To generate the `nix-your-shell.nu` file:
 
 Either manually generate it:
 
-```sh
-nix-your-shell nu | save nix-your-shell.nu
+```nu
+nix-your-shell nu | save $env.XDG_CONFIG_HOME/nushell/nix-your-shell.nu
 ```
 
-Or populate its content through flakes and home-manager:
+Or better yet, ensure it's kept updated alongside `nix-your-shell`. Populate file contents through home-manager:
 
 ```nix
 { config, pkgs, ... }: {

--- a/data/env.nu
+++ b/data/env.nu
@@ -11,10 +11,10 @@ def call-wrapper (command: string, args: list<string>) {
   }
 }
 
-extern-wrapped nix-shell (...args) {
+def --wrapped nix-shell (...args) {
   call-wrapper nix-shell $args
 }
 
-extern-wrapped nix (...args) {
+def --wrapped nix (...args) {
   call-wrapper nix $args
 }

--- a/data/env.nu
+++ b/data/env.nu
@@ -1,10 +1,9 @@
 # If you see this output, you probably forgot to pipe it into `source`:
 # nix-your-shell nu | save nix-your-shell.nu
 
-def call-wrapper (command: string, args: list<string>) {
+def _nix_your_shell (command: string, args: list<string>) {
   if not (which nix-your-shell | is-empty) {
     let args = ["--"] ++ $args
-
     run-external nix-your-shell $command $args
   } else {
     run-external $command $args
@@ -12,9 +11,9 @@ def call-wrapper (command: string, args: list<string>) {
 }
 
 def --wrapped nix-shell (...args) {
-  call-wrapper nix-shell $args
+  _nix_your_shell nix-shell $args
 }
 
 def --wrapped nix (...args) {
-  call-wrapper nix $args
+  _nix_your_shell nix $args
 }


### PR DESCRIPTION
Comply with changes made in Nushell version `0.87.0`. Rename calling function to not conflict with something user defined. Lastly, rewrite readme section to be more informative.