### PR TITLE
Fix nushell with --nom, make shell bits templated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +333,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "minijinja"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe0ff215195a22884d867b547c70a0c4815cbbcc70991f281dca604b20d10ce"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +359,7 @@ dependencies = [
  "camino",
  "clap",
  "color-eyre",
+ "minijinja",
  "shell-words",
  "tracing",
  "tracing-subscriber",
@@ -471,6 +488,29 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+
+[[package]]
+name = "serde"
+version = "1.0.185"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
+
+[[package]]
+name = "serde_json"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0652c533506ad7a2e353cce269330d6afd8bdfb6d75e0ace5b35aacbd7b9e9"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ calm_io = "0.1.1"
 camino = "1.1.4"
 clap = { version = "4.3.4", features = ["derive", "wrap_help", "env"] }
 color-eyre = "0.6.2"
+minijinja = { version = "1.0.12", features = ["json"] }
 shell-words = "1.1.0"
 tracing = { version = "0.1.39", features = ["attributes"] }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter", "registry"] }

--- a/data/env.fish.j2
+++ b/data/env.fish.j2
@@ -2,9 +2,9 @@
 # nix-your-shell | source
 
 function nix-shell --description "Start an interactive shell based on a Nix expression"
-    nix-your-shell nix-shell -- $argv
+    {{ executable }} {{ extra_args | join(" ") }} fish nix-shell -- $argv
 end
 
 function nix --description "Reproducible and declarative configuration management"
-    nix-your-shell nix -- $argv
+    {{ executable }} {{ extra_args | join(" ") }} fish nix -- $argv
 end

--- a/data/env.nu.j2
+++ b/data/env.nu.j2
@@ -2,9 +2,14 @@
 # nix-your-shell nu | save nix-your-shell.nu
 
 def _nix_your_shell (command: string, args: list<string>) {
-  if not (which nix-your-shell | is-empty) {
+  if not (which {{ executable }} | is-empty) {
+    {%- if extra_args %}
+    {#- If you squint hard enough, JSON lists are just Nu lists #}
+    let args = {{ extra_args | tojson }} ++ ["--"] ++ $args
+    {%- else %}
     let args = ["--"] ++ $args
-    run-external nix-your-shell $command ...$args
+    {%- endif %}
+    run-external {{ executable }} $command ...$args
   } else {
     run-external $command ...$args
   }

--- a/data/env.sh.j2
+++ b/data/env.sh.j2
@@ -2,9 +2,9 @@
 # nix-your-shell | source /dev/stdin
 
 function nix-shell () {
-    nix-your-shell nix-shell -- "$@"
+    {{ executable }} {{ extra_args | join(" ") }} {{ shell }} nix-shell -- "$@"
 }
 
 function nix () {
-    nix-your-shell nix -- "$@"
+    {{ executable }} {{ extra_args | join(" ") }} {{ shell }} nix -- "$@"
 }

--- a/data/env.xsh
+++ b/data/env.xsh
@@ -1,5 +1,0 @@
-# If you see this output, you probably forgot to pipe it into `source`:
-# nix-your-shell | source
-
-aliases['nix-shell'] = 'nix-your-shell nix-shell -- @($args)'
-aliases['nix'] = 'nix-your-shell nix -- @($args)'

--- a/data/env.xsh.j2
+++ b/data/env.xsh.j2
@@ -1,0 +1,5 @@
+# If you see this output, you probably forgot to pipe it into `source`:
+# nix-your-shell | source
+
+aliases['nix-shell'] = '{{ executable }} {{ extra_args | join(" ") }} xonsh nix-shell -- @($args)'
+aliases['nix'] = '{{ executable }} {{ extra_args | join(" ") }} xonsh nix -- @($args)'


### PR DESCRIPTION
The nu template uses the executable very differently from others, so it ends up trying weird things like `which nix-your-shell --nom`, which fails because `which` doesn't understand `--nom`.

The other shell templates are also broken as shell _scripts_, because they rely on the `nix-your-shell` -> `nix-your-shell $shell` substitution.

Fix everything by using a real template engine.