### PR TITLE
Don't include version numbers in check names

### DIFF
--- a/nix/packages/make-checks.nix
+++ b/nix/packages/make-checks.nix
@@ -9,7 +9,7 @@ lib.pipe pkgs [
             check:
               lib.nameValuePair
               # The Nix CLI doesn't like attribute names that contain dots.
-              (builtins.replaceStrings ["."] ["-"] check.name)
+              (builtins.replaceStrings ["."] ["-"] check.pname)
               check
           ))
       ]


### PR DESCRIPTION
This makes it impossible to mark them required