### PR TITLE
Change `programs.fish.promptInit` to `programs.fish.interactiveShellInit` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Add to a NixOS flake configuration using the overlay:
   # Example configuration for `fish`:
   programs.fish = {
     enable = true;
-    promptInit = ''
+    interactiveShellInit = ''
       nix-your-shell fish | source
     '';
   };


### PR DESCRIPTION
`promptInit` is deprecated in stable