### PR TITLE
Release version 1.4.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "nix-your-shell"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "calm_io",
  "camino",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nix-your-shell"
-version = "1.4.5"
+version = "1.4.6"
 edition = "2021"
 authors = ["Rebecca Turner <rebeccat@mercury.com>"]
 description = "A `nix` and `nix-shell` wrapper for shells other than `bash`"


### PR DESCRIPTION
Update version to 1.4.6 with [cargo-release](https://github.com/crate-ci/cargo-release).
Merge this PR to build and publish a new release.