### PR TITLE
use list<any> for _nix_your_shell args

### DIFF
--- a/data/env.nu.j2
+++ b/data/env.nu.j2
@@ -1,7 +1,7 @@
 # If you see this output, you probably forgot to pipe it into `source`:
 # nix-your-shell nu | save nix-your-shell.nu
 
-def _nix_your_shell (command: string, args: list<string>) {
+def _nix_your_shell (command: string, args: list<any>) {
   if not (which {{ executable }} | is-empty) {
     {%- if extra_args %}
     {#- If you squint hard enough, JSON lists are just Nu lists #}


### PR DESCRIPTION
Currently, running nix with any value Nushell doesn't parse as a string, such as an integer, float, or boolean, will cause an error, because _nix_your_shell expects only a list of strings. 
```
Error: nu::shell::cant_convert

  × Can't convert to list<string>.
    ╭─[/nix/store/g6kcdm7nshmpljh6cfg6nrmkfs178hwj-nix-your-shell-nushell-config.nu:18:23]
 17 │ def --wrapped nix (...args) {
 18 │   _nix_your_shell nix $args
    ·                       ──┬──
    ·                         ╰── can't convert list<any> to list<string>
 19 │ }
    ╰────
```