### PR TITLE
nushell: fix extra args and make the file `use`able

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ execx($(nix-your-shell xonsh))
 > Nushell version >=0.87.0 is required
 
 > [!NOTE]
-> Nushell requires sourced configuration files to exist before `nu` is started.
+> Nushell requires configuration files to exist before `nu` is started.
 
 Add to your `~/.config/nushell/config.nu`:
 
 ```nu
-source nix-your-shell.nu
+overlay use ~/.config/nushell/nix-your-shell.nu
 ```
 
 To generate the `nix-your-shell.nu` file:

--- a/data/env.nu.j2
+++ b/data/env.nu.j2
@@ -1,24 +1,23 @@
 # If you see this output, you probably forgot to pipe it into `source`:
 # nix-your-shell nu | save nix-your-shell.nu
 
-def _nix_your_shell (command: string, args: list<any>) {
-  if not (which {{ executable }} | is-empty) {
+def nix_your_shell [command: string, args: list<any>] {
+  let args = [$command ...$args]
+  if (which {{ executable }} | is-not-empty) {
     {%- if extra_args %}
     {#- If you squint hard enough, JSON lists are just Nu lists #}
-    let args = {{ extra_args | tojson }} ++ ["--"] ++ $args
-    {%- else %}
-    let args = ["--"] ++ $args
+    let args = $args | insert 0 {{ extra_args | tojson }} | flatten
     {%- endif %}
-    run-external {{ executable }} nu $command ...$args
+    run-external {{ executable }} nu ...$args
   } else {
-    run-external $command ...$args
+    run-external ...$args
   }
 }
 
-def --wrapped nix-shell (...args) {
-  _nix_your_shell nix-shell $args
+export def --wrapped nix-shell [...args] {
+  nix_your_shell nix-shell $args
 }
 
-def --wrapped nix (...args) {
-  _nix_your_shell nix $args
+export def --wrapped nix [...args] {
+  nix_your_shell nix $args
 }


### PR DESCRIPTION
Previously, when extra args is supplied to the generated Nushell file, the following error can happen.
```
error: unexpected argument '--nom' found

  tip: to pass '--nom' as a value, use '-- --nom'

Usage: nix-your-shell <SHELL> nix [ARGS]...

For more information, try '--help'.
```

This PR fixes that and also refactor some of the code to make it `use`able, this means you can also manage it via `overlay`.