### PR TITLE
Use square brackets for nushell args

### DIFF
--- a/data/env.nu.j2
+++ b/data/env.nu.j2
@@ -1,7 +1,7 @@
 # If you see this output, you probably forgot to pipe it into `source`:
 # nix-your-shell nu | save nix-your-shell.nu
 
-def _nix_your_shell (command: string, args: list<any>) {
+def _nix_your_shell [command: string, args: list<any>] {
   if not (which {{ executable }} | is-empty) {
     {%- if extra_args %}
     {#- If you squint hard enough, JSON lists are just Nu lists #}
@@ -16,11 +16,11 @@ def _nix_your_shell (command: string, args: list<any>) {
 }
 
 @complete external
-def --wrapped nix-shell (...args) {
+def --wrapped nix-shell [...args] {
   _nix_your_shell nix-shell $args
 }
 
 @complete external
-def --wrapped nix (...args) {
+def --wrapped nix [...args] {
   _nix_your_shell nix $args
 }


### PR DESCRIPTION
Replaces parentheses with square brackets for nushell custom command args.

(This PR previously also contained identical changes to #113, fixing #110.)