### PR TITLE
fix: nushell completion

### DIFF
--- a/data/env.nu.j2
+++ b/data/env.nu.j2
@@ -15,10 +15,12 @@ def _nix_your_shell (command: string, args: list<any>) {
   }
 }
 
+@complete external
 def --wrapped nix-shell (...args) {
   _nix_your_shell nix-shell $args
 }
 
+@complete external
 def --wrapped nix (...args) {
   _nix_your_shell nix $args
 }


### PR DESCRIPTION
FIXES: #110

https://www.nushell.sh/commands/docs/attr_complete_external.html

I tested it locally and it indeed successfully fixed #110 while still making nix-your-shell work